### PR TITLE
fix: added timeout option for cmd_exec_rc to stop make from timing out

### DIFF
--- a/actions/cmd.py
+++ b/actions/cmd.py
@@ -116,8 +116,8 @@ def cmd_exec(args, wd=None, shell=False, check=True, timeout=TIMEOUT,
     return presults
 
 
-def cmd_exec_rc(args, wd=None):
-    presults = cmd_exec(args, wd=wd, check=False)
+def cmd_exec_rc(args, wd=None, timeout=None):
+    presults = cmd_exec(args, wd=wd, check=False, timeout=timeout)
     return presults.returncode
 
 

--- a/actions/test.py
+++ b/actions/test.py
@@ -174,7 +174,7 @@ class Test:
                 if not os.path.isfile(mfu_path) and not os.path.isfile(mfl_path):
                     build_err = f'Makefile not found: {mfu_path}'
                 else:
-                    if cmd_exec_rc(['make', '-C', repo_path]) != 0:
+                    if cmd_exec_rc(['make', '-C', repo_path], timeout=30) != 0:
                         build_err = 'Program did not make successfully'
         else:
             fatal(f'Unknown build plan: \"{b}\"')


### PR DESCRIPTION
When testing students' repos, many will timeout during the build process because `make` runs with the default timeout in actions.cmd (5 seconds). Now, cmd_exec_rc still uses the default timeout but can accept timeout as a parameter. This allows for actions.test to provided a timeout for make (now defaulted to 30 seconds)