### PR TITLE
fix: cmd_exec_rc uses default timeout as default rather than None

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@
 1. You can test a project in the current directory like this
     ```
     $ cd ~/project02-phpeterson-usf
-    $ grade test --project project02
+    $ grade test
     ```
+    note that `grade` will intuit the project to test based on your current directory.
 ---
 ## Usage for Instructors
 1. Add your Github Classroom organization and a list of students to `~/.config/grade/config.toml`

--- a/actions/cmd.py
+++ b/actions/cmd.py
@@ -116,7 +116,7 @@ def cmd_exec(args, wd=None, shell=False, check=True, timeout=TIMEOUT,
     return presults
 
 
-def cmd_exec_rc(args, wd=None, timeout=None):
+def cmd_exec_rc(args, wd=None, timeout=TIMEOUT):
     presults = cmd_exec(args, wd=wd, check=False, timeout=timeout)
     return presults.returncode
 

--- a/actions/config.py
+++ b/actions/config.py
@@ -7,7 +7,7 @@ import tomlkit
 from actions.test import Test
 from actions.canvas import Canvas, CanvasMapper
 from actions.git import Git
-from actions.util import load_toml
+from actions.util import load_toml, parse_project_name
 
 
 class Args:
@@ -27,7 +27,7 @@ class Args:
         p.add_argument('-n', '--test-name', help='Run test case with this name',
             default=None)
         p.add_argument('-p', '--project', help='Project name',
-            default=None)
+            default=parse_project_name(Path.cwd()))
         p.add_argument('-s', '--students', help='List of GitHub usernames', nargs='+',
             default=None)
         p.add_argument('-v', '--verbose', action='store_true', help='Print actual and expected output when they don\'t match',

--- a/actions/config.py
+++ b/actions/config.py
@@ -7,7 +7,7 @@ import tomlkit
 from actions.test import Test
 from actions.canvas import Canvas, CanvasMapper
 from actions.git import Git
-from actions.util import load_toml, parse_project_name
+from actions.util import load_toml, project_from_cwd
 
 
 class Args:
@@ -27,7 +27,7 @@ class Args:
         p.add_argument('-n', '--test-name', help='Run test case with this name',
             default=None)
         p.add_argument('-p', '--project', help='Project name',
-            default=parse_project_name(Path.cwd()))
+            default=project_from_cwd(Path.cwd()))
         p.add_argument('-s', '--students', help='List of GitHub usernames', nargs='+',
             default=None)
         p.add_argument('-v', '--verbose', action='store_true', help='Print actual and expected output when they don\'t match',

--- a/actions/util.py
+++ b/actions/util.py
@@ -57,3 +57,12 @@ def load_toml(path):
 
 def make_repo_path(project, student):
     return f'{project}-{student}'
+
+def parse_project_name(cwd):
+    # if the current directory is named like a given project (project-username),
+    # use that as the project name
+    # eg. if cwd is '/path/to/project1-phpeterson', return 'project1'
+    # otherwise, use the current directory name
+    # eg. if cwd is '/path/to/project1', use 'project1'
+    i = cwd.name.find('-')
+    return cwd.name if i == -1 else cwd.name[:i]

--- a/actions/util.py
+++ b/actions/util.py
@@ -58,7 +58,7 @@ def load_toml(path):
 def make_repo_path(project, student):
     return f'{project}-{student}'
 
-def parse_project_name(cwd):
+def project_from_cwd(cwd):
     # if the current directory is named like a given project (project-username),
     # use that as the project name
     # eg. if cwd is '/path/to/project1-phpeterson', return 'project1'


### PR DESCRIPTION
Previously, `cmd_exec_rc` defaults `timeout` to `None` which causes `rc` commands other than `make` to fail with a `TypeError`. 
(eg. `grade clone -p <project>` yields: `TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'`

Now `cmd_exec_rc` defaults to the default `TIMEOUT` in `actions.cmd`. This resolves the rc type issues introduced from the last pull-request.