### PR TITLE
Clean up output format

### DIFF
--- a/actions/test.py
+++ b/actions/test.py
@@ -98,16 +98,15 @@ class TestCase:
         cmd_line_str = ' '.join(cmd_line)
 
         if self.args.very_verbose:
-            print(f"===[{self.tc_cfg.name}]===expected\n$ {cmd_line_str}\n{exp}")
+            print(f"\n\n===[{self.tc_cfg.name}]===expected\n$ {cmd_line_str}\n{exp}")
             print()
             print(f"===[{self.tc_cfg.name}]===actual\n$ {cmd_line_str}\n{act}")
-            print()
+
         if self.args.verbose and (act != exp):
-            print(f"===[{self.tc_cfg.name}]===diff\n$ {cmd_line_str}")
+            print(f"\n\n===[{self.tc_cfg.name}]===diff\n$ {cmd_line_str}")
             diff = difflib.context_diff(exp, act, fromfile='expected', tofile='actual')
             for line in diff:
                 print(line, end='')
-            print()
 
         return act == exp
 


### PR DESCRIPTION
This patch cleans up the output format when using `-v/--verbose` and `-vv/--very-verbose` flags.

This is what it currently looks like:

```
. ===[fib_rec]===expected
$ ./project04 fib_rec 10
['c: 55\n', 'asm: 55\n', 'emu: 55\n']

===[fib_rec]===actual
$ ./project04 fib_rec 10
['c: 55\n', 'asm: 55\n', 'emu: 55\n']

fib_rec(4/4) ===[get_bitseq]===expected
$ ./project04 get_bitseq 94116 12 15
['c: 6\n', 'asm: 6\n', 'emu: 6\n']

===[get_bitseq]===actual
$ ./project04 get_bitseq 94116 12 15
['c: 6\n', 'asm: 6\n', 'emu: 6\n']

get_bitseq(4/4) ===[int_to_str]===expected
$ ./project04 int_to_str 255 -o 16
['c: 0xff\n', 'asm: 0xff\n', 'emu: 0xff\n']

===[int_to_str]===actual
$ ./project04 int_to_str 255 -o 16
['c: 0xff\n', 'asm: 0xff\n', 'emu: 0xff\n']

int_to_str(5/5) ===[is_pal]===expected

...
```

This is what it looks like after:

```
===[fib_rec]===expected
$ ./project04 fib_rec 10
['c: 55\n', 'asm: 55\n', 'emu: 55\n']

===[fib_rec]===actual
$ ./project04 fib_rec 10
['c: 55\n', 'asm: 55\n', 'emu: 55\n']
fib_rec(4/4)

===[get_bitseq]===expected
$ ./project04 get_bitseq 94116 12 15
['c: 6\n', 'asm: 6\n', 'emu: 6\n']

===[get_bitseq]===actual
$ ./project04 get_bitseq 94116 12 15
['c: 6\n', 'asm: 6\n', 'emu: 6\n']
get_bitseq(4/4)

===[int_to_str]===expected
$ ./project04 int_to_str 255 -o 16
['c: 0xff\n', 'asm: 0xff\n', 'emu: 0xff\n']

===[int_to_str]===actual
$ ./project04 int_to_str 255 -o 16
['c: 0xff\n', 'asm: 0xff\n', 'emu: 0xff\n']
int_to_str(5/5)

...
```

In the original format, the output doesn't group logically by each test case, with the name of the current test case on the same line as the start of the next test case output. This confuses me sometimes, and I've also heard from other students about how it often can be hard to read. The new format starts each test case diff output on a newline along with an empty line separating it from the previous test case, and also removes the extra line between the current test case output and its title.