### PR TITLE
Added project level config support for capture_stderr

### DIFF
--- a/actions/cmd.py
+++ b/actions/cmd.py
@@ -46,7 +46,7 @@ def cmd_cleanup():
 
 
 def cmd_exec(args, wd=None, shell=False, check=True, timeout=TIMEOUT,
-             output_limit=OUTPUT_LIMIT):
+             output_limit=OUTPUT_LIMIT, capture_stderr=True):
     presults = ProcResults(0, None, None)
 
     global global_cleanup_registered
@@ -57,8 +57,14 @@ def cmd_exec(args, wd=None, shell=False, check=True, timeout=TIMEOUT,
         global_cleanup_registered = True    
         atexit.register(cmd_cleanup)
 
+    # stderr
+    if capture_stderr:
+        stderr=subprocess.STDOUT
+    else:
+        stderr=subprocess.DEVNULL
+    
     try:
-        proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, 
+        proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=stderr, 
                              start_new_session=True, cwd=wd, shell=shell)
 
         #os.set_blocking(proc.stdout.fileno(), False)
@@ -121,13 +127,16 @@ def cmd_exec(args, wd=None, shell=False, check=True, timeout=TIMEOUT,
     return presults
 
 
-def cmd_exec_rc(args, wd=None, timeout=TIMEOUT):
-    presults = cmd_exec(args, wd=wd, check=False, timeout=timeout)
+def cmd_exec_rc(args, wd=None, timeout=TIMEOUT, capture_stderr=True):
+    presults = cmd_exec(args, wd=wd, check=False, timeout=timeout,
+                        capture_stderr=capture_stderr)
     return presults.returncode
 
 
-def cmd_exec_capture(args, wd=None, path=None, shell=False, timeout=TIMEOUT):
-    presults = cmd_exec(args, wd=wd, shell=shell, check=True, timeout=timeout)
+def cmd_exec_capture(args, wd=None, path=None, shell=False, timeout=TIMEOUT,
+                     capture_stderr=True):
+    presults = cmd_exec(args, wd=wd, shell=shell, check=True, timeout=timeout,
+                        capture_stderr=capture_stderr)
     if (path):
         # capture output written to path
         with open(path, 'r') as f:

--- a/actions/test.py
+++ b/actions/test.py
@@ -61,13 +61,16 @@ class TestCase:
 
     def get_actual(self, local):
         timeout = self.project_cfg.timeout
+        capture_stderr = self.project_cfg.capture_stderr
         if self.tc_cfg.output == 'stdout':
             # get actual output from stdout
-            act = cmd_exec_capture(self.cmd_line, local, timeout=timeout)
+            act = cmd_exec_capture(self.cmd_line, local, timeout=timeout, 
+                                   capture_stderr=capture_stderr)
         else:
             # ignore stdout and get actual output from the specified file
             path = os.path.join(local, self.tc_cfg.output)
-            act = cmd_exec_capture(self.cmd_line, local, path, timeout=timeout)
+            act = cmd_exec_capture(self.cmd_line, local, path, timeout=timeout,
+                                   capture_stderr=capture_stderr)
     
         if self.project_cfg.strip_output:
             act = act.replace(self.project_cfg.strip_output, '')
@@ -124,6 +127,7 @@ class ProjectConfig(Config):
         self.strip_output = None
         self.subdir = None
         self.timeout = TIMEOUT
+        self.capture_stderr = True
         self.safe_update(cfg)
 
 class Test:


### PR DESCRIPTION
The setting capture_stderr == true is current behavior and default behavior with this change. When capture_stderr == false means stderr will not be captured for grading purposes or propagated to the console. This fixes autograder tests for Java and Digital.jar on macOS Sequoia in which java emitted warnings to stderr causing tests to fail. The setting capture_stderr = false must be added to the [project] section of a test TOML file:

[project]
...
capture_stderr = false
