### PR TITLE
Fix config.toml creation when running from home directory

### DIFF
--- a/actions/config.py
+++ b/actions/config.py
@@ -70,7 +70,7 @@ class Config:
 
 
     @staticmethod
-    def get_path(verbose):
+    def get_path(verbose=False):
         fname = 'config.toml'
         if os.environ.get('GRADE_CONFIG_DIR'):
             # First choice: config file in dir named by env var
@@ -84,8 +84,12 @@ class Config:
                 if p.exists():
                     found = True
                 else:
+                    # Check if we've reached home directory before moving up
+                    if dirname == Path.home():
+                        break
                     dirname = dirname.parent
-                    if dirname == Path('~').expanduser():
+                    # Also stop if we've reached the root
+                    if dirname == dirname.parent:
                         break
             if not found:
                 # Last choice: config file will be read (and created) in ~/.config

--- a/grade
+++ b/grade
@@ -55,10 +55,17 @@ def make_student_list(cfg, args):
         mapper = CanvasMapper(cfg.canvas_mapper_cfg)
         students = mapper.get_github_list()
         if not students:
-            fatal(f"Must either 'test' one repo or give a list of students in {Config.get_path()}")
+            fatal(f"Must either 'test' one repo or give a list of students in {Config.get_path(verbose=False)}")
     return students
 
 def main():
+    # Ensure config file exists before parsing arguments
+    # This way, even if user runs just 'grade' without arguments,
+    # the config file will be created
+    config_path = Config.get_path(verbose=False)
+    if not config_path.exists():
+        Config.from_path(config_path)
+    
     args = Args.from_cmdline()
     cfg = Config.from_path(Config.get_path(args.verbose))
 


### PR DESCRIPTION
This commit addresses two issues with the default config file creation:

1. Fixed directory traversal logic that prevented config creation when running grade from the home directory. The traversal now correctly stops at the home directory instead of continuing to root.

2. Ensured config.toml is created even when grade is run without arguments. Previously, argparse would exit before config creation code was reached.

Changes:
- Modified Config.get_path() to have optional verbose parameter
- Added early config creation in main() before argument parsing
- Fixed parent directory traversal to properly stop at home directory
- Added safeguard to stop traversal at filesystem root

🤖 Generated with [Claude Code](https://claude.ai/code)