### PR TITLE
Fix pyproject error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,15 +17,6 @@ dependencies = [
     "urllib3",
 ]
 
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-python_files = ["test_*.py"]
-addopts = "-ra"
-filterwarnings = [
-    "ignore:cannot collect test class 'Test':pytest.PytestCollectionWarning",
-    "ignore:cannot collect test class 'TestCase':pytest.PytestCollectionWarning",
-]
-
 [project.scripts]
 grade = "autograder.grade:main" # `uv run grade`
 


### PR DESCRIPTION
> ERROR Failed to parse /build/source/pyproject.toml: Cannot declare ('tool', 'pytest', 'ini_options') twice (at line 32, column 25)